### PR TITLE
System Test screenshots path configurable

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -15,8 +15,11 @@ module ActionDispatch
         #
         # The screenshot will be displayed in your console, if supported.
         #
+        # The default screenshots directory is +tmp/screenshots+ but you can set a different
+        # one with +Capybara.save_path+
+        #
         # You can set the +RAILS_SYSTEM_TESTING_SCREENSHOT_HTML+ environment variable to
-        # save the HTML from the page that is being screenhoted so you can investigate the
+        # save the HTML from the page that is being screenshotted so you can investigate the
         # elements on the page at the time of the screenshot
         #
         # You can set the +RAILS_SYSTEM_TESTING_SCREENSHOT+ environment variable to
@@ -76,7 +79,11 @@ module ActionDispatch
           end
 
           def absolute_path
-            Rails.root.join("tmp/screenshots/#{image_name}")
+            Rails.root.join(screenshots_dir, image_name)
+          end
+
+          def screenshots_dir
+            Capybara.save_path.presence || "tmp/screenshots"
           end
 
           def absolute_image_path

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -36,6 +36,17 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     end
   end
 
+  test "image path uses the Capybara.save_path to set a custom directory" do
+    original_save_path = Capybara.save_path
+    Capybara.save_path = "custom_dir"
+
+    Rails.stub :root, Pathname.getwd do
+      assert_equal Rails.root.join("custom_dir/0_x.png").to_s, @new_test.send(:image_path)
+    end
+  ensure
+    Capybara.save_path = original_save_path
+  end
+
   test "image path includes failures text if test did not pass" do
     Rails.stub :root, Pathname.getwd do
       @new_test.stub :passed?, false do


### PR DESCRIPTION
### Summary

If you set a custom directory to store the screenshots using `Capybara.save_path` [ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper#absolute_path](https://github.com/rails/rails/blob/c049f16ae3731eeff9753bd479c828cda1e82b49/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L78) doesn't use that value because the directory is hard-coded to `tmp/screenshots`

Now we can set a custom directory to store the screenshots setting it in `Capybara.save_path` before using [ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelpe.take_screenshot](https://github.com/rails/rails/blob/c049f16ae3731eeff9753bd479c828cda1e82b49/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L30)

**To take into consideration:** When we run bin/rails tmp:screenshots:clear the screenshot stored in this custom directory will not be removed

### Other Information
References:

Fixes: ....
